### PR TITLE
commit by adityatiwari

### DIFF
--- a/500098216/Docker.yml
+++ b/500098216/Docker.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+
+services:
+  web:
+    image: my-python-app  # Replace with the image name for your Python application
+    ports:
+      - "5000:80"
+    depends_on:
+      - db
+  db:
+    image: postgres
+    environment:
+      POSTGRES_DB: mydatabase
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: mypassword


### PR DESCRIPTION
The provided Docker Compose YAML file defines a multi-container Docker application with two services:

web: This service runs a Python application (replace my-python-app with your image name) and exposes it on port 5000, mapping it to port 80 on the host. It depends on the db service.

db: This service runs a PostgreSQL database with specified environment variables (database name, user, and password).

Using docker-compose up, you can start both services simultaneously, ensuring that the database service is started before the web service.