### PR TITLE
Create hatrshit.Dockerfile

### DIFF
--- a/hatrshit.Dockerfile
+++ b/hatrshit.Dockerfile
@@ -1,0 +1,20 @@
+# Use an official Node.js runtime as the base image
+FROM node:14
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json to the working directory
+COPY package*.json ./
+
+# Install application dependencies
+RUN npm install
+
+# Copy the rest of the application source code
+COPY . .
+
+# Expose a port that the application will listen on
+EXPOSE 3000
+
+# Define the command to start your application
+CMD [ "node", "app.js" ]


### PR DESCRIPTION
Uses the official Node.js base image with version 14.
Sets the working directory in the container to /usr/src/app.
Copies the package.json and package-lock.json files into the container to install the application dependencies.
Runs npm install to install the dependencies.
Copies the rest of the application source code into the container.
Exposes port 3000 for the application to listen on (you can adjust this port as needed).
Defines the command to start the application, which is node app.js in this example.
You can customize this Dockerfile based on the requirements of your specific application and the base image you want to use.